### PR TITLE
Feature/fix nami wallet problems

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+
 import { State, useStore } from './store';
 import { WalletName } from './typescript/cip30';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ const useCardanoWallet = ({
         connectWithStore(connectedWalletName, localStorageKey);
       }, 10);
     }
-  }, [autoConnect, localStorageKey, (window as any).cardano]);
+  }, [autoConnect, localStorageKey]);
 
   const connect = async (walletName: WalletName) => {
     await connectWithStore(walletName, localStorageKey);

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ const useCardanoWallet = ({
         connectWithStore(connectedWalletName, localStorageKey);
       }, 10);
     }
-  }, [autoConnect, localStorageKey]);
+  }, [autoConnect, localStorageKey, connectWithStore]);
 
   const connect = async (walletName: WalletName) => {
     await connectWithStore(walletName, localStorageKey);


### PR DESCRIPTION
This PR makes the hook work with nami wallet by falling back to `getUsedAddresses` when getting the raw address.

![image](https://user-images.githubusercontent.com/11805103/196408383-7f3b4215-cd43-45c3-8135-915a13892f77.png)

This PR builds on #5, so that PR should be merged first, and I can rebase this after that. This PR also superseeds #2 but only fixes the original issue, but disregards potential problems with `getBalance`, as per @MartinSchere's comment in that PR. Me myself did not have a problem with `getBalance`, but @muhammadumer-sl2 reportedly did, so not sure why that was.

I also applied a small refactor for clarity.